### PR TITLE
Update deprecated dependancy on x11-proto

### DIFF
--- a/x11-terms/rxvt-unicode/rxvt-unicode-9.22-r6.ebuild
+++ b/x11-terms/rxvt-unicode/rxvt-unicode-9.22-r6.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 DEPEND="
 	${RDEPEND}
 	virtual/pkgconfig
-	x11-proto/xproto
+	x11-base/xorg-proto
 "
 PATCHES=(
 	"${FILESDIR}"/${PN}-9.06-case-insensitive-fs.patch


### PR DESCRIPTION
Since https://bugs.gentoo.org/656250 x11-proto has been merged into x11-base/xorg-proto